### PR TITLE
Cancel Active Listings on Transfer

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,4 +1,4 @@
-import { BigInt, log, store } from "@graphprotocol/graph-ts";
+import { Address, BigInt, log, store } from "@graphprotocol/graph-ts";
 import { Exerciser, Listing, Student, UserToken } from "../generated/schema";
 import {
   ItemCanceled,
@@ -44,19 +44,21 @@ function formatPrice(number: BigInt): string {
 
 export function handleItemCanceled(event: ItemCanceled): void {
   let params = event.params;
-  let seller = params.seller;
+  cancelItem(params.seller, params.nftAddress, params.tokenId);
+}
 
+export function cancelItem(seller: Address, tokenAddress: Address, tokenId: BigInt): void {
   let listing = getOrCreateListing(
-    getListingId(seller, params.nftAddress, params.tokenId)
+    getListingId(seller, tokenAddress, tokenId)
   );
   let user = getOrCreateUser(seller.toHexString());
 
   if (!listing) {
-    log.info("[Listing is null]: {}", [params.seller.toHexString()]);
+    log.info("[Listing is null]: {}", [seller.toHexString()]);
     return;
   }
   if (!user) {
-    log.info("[User is null]: {}", [params.seller.toHexString()]);
+    log.info("[User is null]: {}", [seller.toHexString()]);
     return;
   }
 

--- a/src/mappings/1155.ts
+++ b/src/mappings/1155.ts
@@ -26,6 +26,7 @@ import {
   removeFromArray,
   updateCollectionFloorAndTotal,
 } from "../helpers";
+import { cancelItem } from "../mapping";
 
 export function handleTransferSingle(event: TransferSingle): void {
   let params = event.params;
@@ -84,6 +85,9 @@ export function handleTransferSingle(event: TransferSingle): void {
 
     addMetadataToToken(token, ZERO_BI, collection);
   }
+
+  // Remove any active listings from TreasureMarketplace contract
+  cancelItem(params.from, address, tokenId);
 
   let metadata = Metadata.load(token.id);
 

--- a/src/mappings/721.ts
+++ b/src/mappings/721.ts
@@ -30,6 +30,7 @@ import {
   toBigDecimal,
   updateCollectionFloorAndTotal,
 } from "../helpers";
+import { cancelItem } from "../mapping";
 
 export function handleTransfer(event: Transfer): void {
   let params = event.params;
@@ -131,6 +132,9 @@ export function handleTransfer(event: Transfer): void {
       store.remove("UserToken", seller);
     }
   }
+
+  // Remove any active listings from TreasureMarketplace contract
+  cancelItem(params.from, address, tokenId);
 
   userToken.quantity = ONE_BI;
   userToken.token = token.id;

--- a/tests/smol-brains.test.ts
+++ b/tests/smol-brains.test.ts
@@ -19,6 +19,8 @@ import {
   handleDropSchool,
   handleJoinSchool,
 } from "../src/mappings/smol-brains";
+import { Transfer } from "../generated/Smol Brains/ERC721";
+import { handleTransfer } from "../src/mappings/smol-brains";
 
 class Smolbrain extends ERC721 {
   // Not really the tokenId, but this should work for head size
@@ -242,4 +244,17 @@ test("listings are calculated correctly", () => {
     "1"
   );
   assert.notInStore("Listing", `${me.id}-${smolbrain.id}-0x0`);
+});
+
+test("active listing is cancelled after transfering smol", () => {
+  let id = getListingId(me.address, smolbrain.address, BigInt.fromI32(0));
+
+  smolbrain.mint(0, me.id);
+  mp.list(0);
+
+  assert.fieldEquals("Listing", id, "status", "Active");
+
+  smolbrain.transfer(0, me.id, friend.id);
+
+  assert.notInStore("Listing", id);
 });


### PR DESCRIPTION
Deals with issue: #62 

**Problem** 
Listing stays Active on the `TreasureMarketPlace` contract after transfering the Item to another wallet.

Recently we saw some issues with this on Opensea (Apes getting sniped based on old listings).
Cause was that users didn't cancel active listings, but transfered the item back and forth instead (might be cheaper in gas).
After doing this the listings were not visible in the UI but were active in the contract.

Seems like TreasureMarketPlace has the same issue.

**Solution**
Upon transferring, check for active listings and Cancel those.

**Note**
Added an Unittest which passes, however did not test it in a local environment. @wyze, could you add a Readme on how to spin this up correctly?

