### PR TITLE
Add `Token` & `Collection` fulltext search

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -9,6 +9,20 @@ enum TokenStandard {
   ERC1155
 }
 
+type _Schema_
+  @fulltext(
+    name: "tokenSearch"
+    language: en
+    algorithm: rank
+    include: [{ entity: "Token", fields: [{ name: "name" }] }]
+  )
+  @fulltext(
+    name: "collectionSearch"
+    language: en
+    algorithm: rank
+    include: [{ entity: "Collection", fields: [{ name: "name" }] }]
+  )
+
 type Attribute @entity {
   id: ID!
 
@@ -30,13 +44,13 @@ type Collection @entity {
 
   "Internal for tracking listings"
   _listingIds: [String!]!
-  
+
   "Internal for tracking metadata failures to retry"
   _missingMetadataIds: [String!]!
-  
+
   "Internal for tracking owners of tokens for a collection"
   _owners: [String!]!
-  
+
   "Internal for tracking tokenIds minted for a collection"
   _tokenIds: [String!]!
 


### PR DESCRIPTION
Implements two fulltext search options. This allows to search for items case insensitive.

This image shows a search of:  `smOL ca`. 
The marketplace can implement these to make searching for items more accessible

[link to playground](https://thegraph.com/hosted-service/subgraph/magiclars-off/treasure-marketplace-dev)
![image](https://user-images.githubusercontent.com/62888804/151854597-3f08f8b2-e751-4389-8691-cbdf2e652987.png)

@wyze
